### PR TITLE
Refactor hamburger menu type casts

### DIFF
--- a/components/hamburger-menu.vue
+++ b/components/hamburger-menu.vue
@@ -73,17 +73,14 @@
 </i18n>
 
 <script lang="ts" setup>
-import type { LocaleObject } from "@nuxtjs/i18n/dist/runtime/composables";
 import type { Locale } from "~/types";
 
 //
 // refs
 //
-const i18n = useI18n<[], Locale>({
+const { locales, t } = useI18n<[], Locale>({
   useScope: "local",
 });
-const locales = <LocaleObject[]>i18n.locales.value;
-const t = i18n.t;
 const open = ref(false);
 
 //
@@ -92,7 +89,10 @@ const open = ref(false);
 const localePath = useLocalePath();
 const switchLocalePath = useSwitchLocalePath();
 const toggleMenu = (evt: MouseEvent): void => {
-  open.value = (<HTMLInputElement>evt.target)?.checked;
+  const target = evt.target;
+  if (target instanceof HTMLInputElement) {
+    open.value = target.checked;
+  }
 };
 const closeMenu = (): void => {
   open.value = false;


### PR DESCRIPTION
Refactor `hamburger-menu.vue` to remove unnecessary type casts and improve type safety.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b2fe074-5783-41b0-8c2a-d6a35a8025c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b2fe074-5783-41b0-8c2a-d6a35a8025c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

